### PR TITLE
Fixed issue with device port updates not being caught

### DIFF
--- a/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -270,6 +270,10 @@ def subscribe() {
     subscribe(getHostAddress())
 }
 
+def sync(ip, port) {
+    subscribe(ip, port)
+}
+
 def subscribe(ip, port) {
     def existingIp = getDataValue("ip")
     def existingPort = getDataValue("port")

--- a/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -253,8 +253,9 @@ def refresh() {
 }
 
 def subscribe(hostAddress) {
-    debug("Executing 'subscribe()'")
+    debug("Executing 'subscribe(${hostAddress})'")
     def address = getCallBackAddress()
+	debug("hostAddress: ${hostAddress}")
     new physicalgraph.device.HubAction("""SUBSCRIBE /upnp/event/basicevent1 HTTP/1.1
 HOST: ${hostAddress}
 CALLBACK: <http://${address}/>
@@ -267,6 +268,7 @@ User-Agent: CyberGarage-HTTP/1.0
 }
 
 def subscribe() {
+    debug("calling getHostAddress()")
     subscribe(getHostAddress())
 }
 

--- a/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -72,9 +72,9 @@ metadata {
 }
 
 private debug(data){
-    //if(parent.appSettings.debug == "true"){
+    if(parent.appSettings.debug == "true"){
         log.debug(data)
-    //}
+    }
 }
 
 // parse events into attributes

--- a/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -72,9 +72,9 @@ metadata {
 }
 
 private debug(data){
-    if(parent.appSettings.debug == "true"){
+    //if(parent.appSettings.debug == "true"){
         log.debug(data)
-    }
+    //}
 }
 
 // parse events into attributes

--- a/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/devicetypes/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -253,9 +253,8 @@ def refresh() {
 }
 
 def subscribe(hostAddress) {
-    debug("Executing 'subscribe(${hostAddress})'")
+    debug("Executing subscribe(${hostAddress})")
     def address = getCallBackAddress()
-	debug("hostAddress: ${hostAddress}")
     new physicalgraph.device.HubAction("""SUBSCRIBE /upnp/event/basicevent1 HTTP/1.1
 HOST: ${hostAddress}
 CALLBACK: <http://${address}/>
@@ -270,10 +269,6 @@ User-Agent: CyberGarage-HTTP/1.0
 def subscribe() {
     debug("calling getHostAddress()")
     subscribe(getHostAddress())
-}
-
-def sync(ip, port) {
-    subscribe(ip, port)
 }
 
 def subscribe(ip, port) {
@@ -292,7 +287,7 @@ def subscribe(ip, port) {
 }
 
 def resubscribe() {
-    debug("Executing 'resubscribe()'")
+    debug("Executing resubscribe()")
     def sid = getDeviceDataByName("subscriptionId")
 
     new physicalgraph.device.HubAction("""SUBSCRIBE /upnp/event/basicevent1 HTTP/1.1

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -128,10 +128,6 @@ def installed() {
     unschedule()
     unsubscribe()
 
-    if (selecteddimmerLightSwitches) {
-        adddimmerLightSwitches()
-    }
-
     // run once subscribeToDevices
     subscribeToDevices()
 
@@ -158,9 +154,6 @@ private removeChildDevices(devices) {
 def updated() {
     debug("Updated with settings: ${settings}")
     unschedule()
-    if (selecteddimmerLightSwitches) {
-        adddimmerLightSwitches()
-    }
 
     // run once subscribeToDevices
     subscribeToDevices()
@@ -186,6 +179,9 @@ def refreshDevices() {
 
 def subscribeToDevices() {
     debug("subscribeToDevices() called")
+    if (selecteddimmerLightSwitches) {
+        adddimmerLightSwitches()
+    }
     def devices = getAllChildDevices()
     devices.each { d ->
         debug('Call subscribe on '+d.id)

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -64,12 +64,10 @@ def firstPage() {
 
         debug("REFRESH COUNT :: ${refreshCount}")
 
-        if(!state.subscribe) {
-            debug("Subscribe to location")
-            // subscribe to answers from HUB
-            subscribe(location, null, locationHandler, [filterEvents:false])
-            state.subscribe = true
-        }
+        
+        debug("Subscribe to location")
+        // subscribe to answers from HUB
+        subscribe(location, null, locationHandler, [filterEvents:false])
 
         //ssdp request every 25 seconds
         if((refreshCount % 5) == 0) {
@@ -196,15 +194,18 @@ def subscribeToDevices() {
 }
 
 def adddimmerLightSwitches() {
+    debug("adddimmerLightSwitches()")
     def dimmerLightSwitches = getWemoDimmerLightSwitches()
-
+    debug("dimmerLightSwitches: ${dimmerLightSwitches}")
     selecteddimmerLightSwitches.each { dni ->
-        def selectedDimmerLightSwitch = dimmerLightSwitches.find { it.value.mac == dni } ?: dimmerLightSwitches.find { "${it.value.ip}:${it.value.port}" == dni }
+        def selectedDimmerLightSwitch = dimmerLightSwitches.find { 
+            debug("it:${it}")
+            it?.value?.mac == dni }
 
         def d
         if (selectedDimmerLightSwitch) {
             d = getChildDevices()?.find {
-                it.dni == selectedDimmerLightSwitch.value.mac || it.device.getDataValue("mac") == selectedDimmerLightSwitch.value.mac
+                it?.dni == selectedDimmerLightSwitch?.value?.mac || it?.device?.getDataValue("mac") == selectedDimmerLightSwitch?.value?.mac
             }
         }
 

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -196,9 +196,7 @@ def adddimmerLightSwitches() {
     debug("adddimmerLightSwitches()")
     def dimmerLightSwitches = getWemoDimmerLightSwitches()
     selecteddimmerLightSwitches.each { dni ->
-        def selectedDimmerLightSwitch = dimmerLightSwitches.find { 
-            debug("it:${it}")
-            it?.value?.mac == dni }
+        def selectedDimmerLightSwitch = dimmerLightSwitches.find { it?.value?.mac == dni }
         def d
         if (selectedDimmerLightSwitch) {
             d = getChildDevices()?.find {

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -32,9 +32,9 @@ preferences {
 }
 
 private debug(data) {
-    if(appSettings.debug == "true"){
+    //if(appSettings.debug == "true"){
         log.debug(data)
-    }
+    //}
 }
 
 private discoverAllWemoTypes() {
@@ -220,7 +220,7 @@ def initialize() {
     subscribeToDevices()
 
     //setup cron jobs
-    schedule("10 * * * * ?", "subscribeToDevices")
+    runEvery5Minutes(subscribeToDevices)
 }
 
 def locationHandler(evt) {

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -251,23 +251,17 @@ def locationHandler(evt) {
         } else { // just update the values
             debug("Updating devices")
             def d = dimmerLightSwitches."${parsedEvent.ssdpUSN.toString()}"
-            boolean deviceChangedValues = false
-
+            debug("parsedEvent:${parsedEvent} d:${d}")
+            
             if(d.ip != parsedEvent.ip || d.port != parsedEvent.port) {
                 d.ip = parsedEvent.ip
                 d.port = parsedEvent.port
-                deviceChangedValues = true
-            }
-
-            if (deviceChangedValues) {
-                def children = getChildDevices()
-                children.each { it ->
-                    if (it.getDeviceDataByName("mac") == parsedEvent.mac) {
-                        it.subscribe(parsedEvent.ip, parsedEvent.port)
-                    }
+                def child = getChildDevice(parsedEvent.mac)
+                if (child) {
+                    debug("triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
+                   child.subscribe(parsedEvent.ip, parsedEvent.port)   
                 }
             }
-
         }
     } else if (parsedEvent.headers && parsedEvent.body) {
         def headerString = new String(parsedEvent.headers.decodeBase64())

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -195,12 +195,10 @@ def subscribeToDevices() {
 def adddimmerLightSwitches() {
     debug("adddimmerLightSwitches()")
     def dimmerLightSwitches = getWemoDimmerLightSwitches()
-    debug("dimmerLightSwitches: ${dimmerLightSwitches}")
     selecteddimmerLightSwitches.each { dni ->
         def selectedDimmerLightSwitch = dimmerLightSwitches.find { 
             debug("it:${it}")
             it?.value?.mac == dni }
-        debug("selectedDimmerLightSwitch:${selectedDimmerLightSwitch}")
         def d
         if (selectedDimmerLightSwitch) {
             d = getChildDevices()?.find {
@@ -249,15 +247,12 @@ def locationHandler(evt) {
         } else { // just update the values
             debug("Updating devices")
             def d = dimmerLightSwitches."${parsedEvent.ssdpUSN.toString()}"
-            debug("parsedEvent:${parsedEvent} d:${d}")
-            
             if(d.ip != parsedEvent.ip || d.port != parsedEvent.port) {
                 d.ip = parsedEvent.ip
                 d.port = parsedEvent.port
                 def child = getChildDevice(parsedEvent.mac)
-                debug("child:${child}")
                 if (child) {
-                   debug("triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
+                   debug("Triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
                    child.subscribe(parsedEvent.ip, parsedEvent.port)   
                 }
             }

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -67,7 +67,7 @@ def firstPage() {
         
         debug("Subscribe to location")
         // subscribe to answers from HUB
-        subscribe(location, null, locationHandler, [filterEvents:false])
+        subscribe(location, "ssdpTerm.urn:Belkin:service:basicevent:1", locationHandler)
 
         //ssdp request every 25 seconds
         if((refreshCount % 5) == 0) {
@@ -223,7 +223,7 @@ def adddimmerLightSwitches() {
             debug("Mac: " + selectedDimmerLightSwitch.value.mac)
             debug("Hub: " + (selectedDimmerLightSwitch?.value.hub))
             debug("Data: " + data)
-            d = addChildDevice("kris2k2", "Wemo Dimmer Light Switch", selectedDimmerLightSwitch.value.mac, (selectedDimmerLightSwitch?.value.hub), data)
+            d = addChildDevice("kris2k2", "Wemo Dimmer Light Switch", selectedDimmerLightSwitch.value.mac, selectedDimmerLightSwitch?.value.hub, data)
         }
     }
 }

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -257,7 +257,7 @@ def locationHandler(evt) {
                 def child = getChildDevice(parsedEvent.mac)
                 debug("child:${child}")
                 if (child) {
-                    debug("triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
+                   debug("triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
                    child.subscribe(parsedEvent.ip, parsedEvent.port)   
                 }
             }

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -183,6 +183,7 @@ def refreshDevices() {
 
 def subscribeToDevices() {
     debug("subscribeToDevices() called")
+    // Need to discover each subscribe call or updated ports wont be caught!
     discoverAllWemoTypes()
     def devices = getAllChildDevices()
     devices.each { d ->
@@ -205,7 +206,6 @@ def adddimmerLightSwitches() {
             d = getChildDevices()?.find {
                 it?.dni == selectedDimmerLightSwitch?.value?.mac || it?.device?.getDataValue("mac") == selectedDimmerLightSwitch?.value?.mac
             }
-            debug("FOUND D:${d}")
         }
 
         if (!d) {
@@ -251,7 +251,7 @@ def locationHandler(evt) {
             def d = dimmerLightSwitches."${parsedEvent.ssdpUSN.toString()}"
             debug("parsedEvent:${parsedEvent} d:${d}")
             
-            //if(d.ip != parsedEvent.ip || d.port != parsedEvent.port) {
+            if(d.ip != parsedEvent.ip || d.port != parsedEvent.port) {
                 d.ip = parsedEvent.ip
                 d.port = parsedEvent.port
                 def child = getChildDevice(parsedEvent.mac)
@@ -260,7 +260,7 @@ def locationHandler(evt) {
                     debug("triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
                    child.subscribe(parsedEvent.ip, parsedEvent.port)   
                 }
-            //}
+            }
         }
     } else if (parsedEvent.headers && parsedEvent.body) {
         def headerString = new String(parsedEvent.headers.decodeBase64())

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -201,12 +201,13 @@ def adddimmerLightSwitches() {
         def selectedDimmerLightSwitch = dimmerLightSwitches.find { 
             debug("it:${it}")
             it?.value?.mac == dni }
-
+        debug("selectedDimmerLightSwitch:${selectedDimmerLightSwitch}")
         def d
         if (selectedDimmerLightSwitch) {
             d = getChildDevices()?.find {
                 it?.dni == selectedDimmerLightSwitch?.value?.mac || it?.device?.getDataValue("mac") == selectedDimmerLightSwitch?.value?.mac
             }
+            debug("FOUND D:${d}")
         }
 
         if (!d) {

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -256,7 +256,7 @@ def locationHandler(evt) {
 
             if (deviceChangedValues) {
                 def children = getChildDevices()
-                children.each {
+                children.each { it ->
                     if (it.getDeviceDataByName("mac") == parsedEvent.mac) {
                         it.subscribe(parsedEvent.ip, parsedEvent.port)
                     }

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -127,7 +127,18 @@ def getWemoDimmerLightSwitches() {
 
 def installed() {
     debug("Installed with settings: ${settings}")
-    initialize()
+    unschedule()
+    unsubscribe()
+
+    if (selecteddimmerLightSwitches) {
+        adddimmerLightSwitches()
+    }
+
+    // run once subscribeToDevices
+    subscribeToDevices()
+
+    //setup cron jobs
+    runEvery5Minutes(subscribeToDevices)
 }
 
 def uninstalled() {
@@ -148,7 +159,16 @@ private removeChildDevices(devices) {
 
 def updated() {
     debug("Updated with settings: ${settings}")
-    initialize()
+    unschedule()
+    if (selecteddimmerLightSwitches) {
+        adddimmerLightSwitches()
+    }
+
+    // run once subscribeToDevices
+    subscribeToDevices()
+
+    //setup cron jobs
+    runEvery5Minutes(subscribeToDevices)
 }
 
 def resubscribe() {
@@ -204,23 +224,6 @@ def adddimmerLightSwitches() {
             d = addChildDevice("kris2k2", "Wemo Dimmer Light Switch", selectedDimmerLightSwitch.value.mac, (selectedDimmerLightSwitch?.value.hub), data)
         }
     }
-}
-
-def initialize() {
-    debug("Initialiaze")
-    // remove location subscription afterwards
-    unsubscribe()
-    state.subscribe = false
-
-    if (selecteddimmerLightSwitches) {
-        adddimmerLightSwitches()
-    }
-
-    // run once subscribeToDevices
-    subscribeToDevices()
-
-    //setup cron jobs
-    runEvery5Minutes(subscribeToDevices)
 }
 
 def locationHandler(evt) {

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -253,15 +253,16 @@ def locationHandler(evt) {
             def d = dimmerLightSwitches."${parsedEvent.ssdpUSN.toString()}"
             debug("parsedEvent:${parsedEvent} d:${d}")
             
-            if(d.ip != parsedEvent.ip || d.port != parsedEvent.port) {
+            //if(d.ip != parsedEvent.ip || d.port != parsedEvent.port) {
                 d.ip = parsedEvent.ip
                 d.port = parsedEvent.port
                 def child = getChildDevice(parsedEvent.mac)
+                debug("child:${child}")
                 if (child) {
                     debug("triggering subscribe on: ${parsedEvent.mac} ${parsedEvent.ip} ${parsedEvent.port}")
                    child.subscribe(parsedEvent.ip, parsedEvent.port)   
                 }
-            }
+            //}
         }
     } else if (parsedEvent.headers && parsedEvent.body) {
         def headerString = new String(parsedEvent.headers.decodeBase64())

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -32,9 +32,9 @@ preferences {
 }
 
 private debug(data) {
-    //if(appSettings.debug == "true"){
+    if(appSettings.debug == "true"){
         log.debug(data)
-    //}
+    }
 }
 
 private discoverAllWemoTypes() {

--- a/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
+++ b/smartapps/kris2k2/wemo-dimmer-light-switch.src/wemo-dimmer-light-switch.groovy
@@ -127,7 +127,9 @@ def installed() {
     debug("Installed with settings: ${settings}")
     unschedule()
     unsubscribe()
-
+    if (selecteddimmerLightSwitches) {
+        adddimmerLightSwitches()
+    }
     // run once subscribeToDevices
     subscribeToDevices()
 
@@ -154,7 +156,9 @@ private removeChildDevices(devices) {
 def updated() {
     debug("Updated with settings: ${settings}")
     unschedule()
-
+    if (selecteddimmerLightSwitches) {
+        adddimmerLightSwitches()
+    }
     // run once subscribeToDevices
     subscribeToDevices()
 
@@ -179,9 +183,7 @@ def refreshDevices() {
 
 def subscribeToDevices() {
     debug("subscribeToDevices() called")
-    if (selecteddimmerLightSwitches) {
-        adddimmerLightSwitches()
-    }
+    discoverAllWemoTypes()
     def devices = getAllChildDevices()
     devices.each { d ->
         debug('Call subscribe on '+d.id)


### PR DESCRIPTION
If left long enough, wemo dimmers will eventually switch the port they are listening on. If we don't catch this, they simply stop responding on SmarthThings. This can be tested by resetting the dimmer (hold down the tiny button at the bottom of the switch until it glows white). One it restarts it will pick a port - usually a new one.

This PR addresses that issue. There are a few other code updates based on best practices that I gleaned from the API docs. The fix is primarily just one line in the subscribeToDevices() function: 

discoverAllWemoTypes()

